### PR TITLE
First draft of updates to accomodate github local

### DIFF
--- a/GitHub-Guide.qmd
+++ b/GitHub-Guide.qmd
@@ -49,9 +49,9 @@ This "best practices" guide was developed by and is maintained by the NMFS Open 
 
 NOAA Fisheries staff have three choices for using GitHub:
 
-1.  **GitHub Enterprise Cloud (GHEC):** GHEC is a service provided by NOAA Fisheries to host GitHub repositories used for conducting NOAA Fisheries work. The repositories are stored on a GitHub-hosted cloud which means that only information that can be stored in a FISMA-low environment should be included in GHEC. If you only are interested in using GitHub for projects that contain sensitive information, mark "No" below and continue to the next questions on the form.
-2.  **GitHub Local:** GitHub Local is designed for users who work with confidential or other sensitive information, unlike GHEC which allows for making your repositories visible to the public and collaborating outside of NOAA Fisheries, . This version of GitHub is located inside the NOAA Fisheries firewalls and therefore provides an added layer of IT security and complies with information handling rules.
-3.  **GitHub Public:** GitHub public is appropriate if you are collaborating on a project that is being led by someone outside of NOAA Fisheries or if non-NOAA collaborators are equal partners on the project.
+1.  **GitHub Enterprise Cloud (GHEC):** GHEC is a service provided by NOAA Fisheries to host GitHub repositories used for conducting NOAA Fisheries work. The repositories are stored on a GitHub-hosted cloud which means that only information that can be stored in a FISMA-low environment should be included in GHEC. The repositories can be public or private. If you only are interested in using GitHub for projects that contain sensitive information, mark "No" below and continue to the next questions on the form.
+2.  **GitHub Local:** GitHub Local is designed for users who work with confidential or other sensitive information. This version of GitHub is located inside the NOAA Fisheries firewalls and therefore provides an added layer of IT security and complies with information handling rules.
+3.  **GitHub Public:** GitHub public is appropriate if you are collaborating on a project that is being led by someone outside of NOAA Fisheries or if non-NOAA collaborators are equal partners on the project. GitHub Public refers to any non-NOAA Fisheries GHEC repository hosted on GitHub.com. The repositories can be public or private.
 
 ```{mermaid}
 


### PR DESCRIPTION
I added info about GHES. A lot of the sections were titled "how to xxx in GitHub" but they only pertain to things that aren't github.nmfs.local. The guidance is the same for orgs in GHEC or not, so I relabeled them to "How to xxx on github.com."  After I pushed my branch, I noticed that when I used the quarto preview feature in positron it converted a lot of bulleted lists from "-" to "*" - I can go change those back, let me know.